### PR TITLE
CORE-2006: updated dependencies and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pom.xml.asc
 test2junit
 build.xml
 *.iml
+.clj-kondo
+.eastwood
+.lsp

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,12 @@
             :url "http://cyverse.org/sites/default/files/iPLANT-LICENSE.txt"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :plugins [[test2junit "1.2.2"]]
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-http "2.0.0"]
+  :plugins [[jonase/eastwood "1.4.3"]
+            [lein-ancient "0.7.0"]
+            [test2junit "1.4.4"]]
+  :dependencies [[org.clojure/clojure "1.11.3"]
+                 [clj-http "3.13.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [cheshire "5.5.0"]
-                 [medley "1.0.0"]
-                 [org.cyverse/kameleon "3.0.0"]])
+                 [cheshire "5.13.0"]
+                 [medley "1.4.0"]
+                 [org.cyverse/kameleon "3.0.10"]])


### PR DESCRIPTION
I was a little concerned about the `clj-http` update, but the [change log][1] only mentioned one breaking change that could be fixed by upgrading to Cheshire >= 5.9.0.

[1]: https://github.com/dakrone/clj-http/blob/3.x/changelog.org